### PR TITLE
workarounds for older but still present db engines

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -51,7 +51,7 @@ jobs:
       run: |
         ldd $(python -c 'import _sqlite3;print(_sqlite3.__file__)')
         sudo cp /usr/local/lib/libsqlite3.so.0 /lib/x86_64-linux-gnu/libsqlite3.so.0
-        python -c 'import sqlite3;print("SQLITE VERSION", sqlite3.sqlite_version_info)'
+        python -c 'import sqlite3,sys;print("SQLITE VERSION", sqlite3.sqlite_version_info);sys.exit(1 if sqlite3.sqlite_version_info < (3, 33) else 0)'
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
@@ -66,8 +66,59 @@ jobs:
         parallel: true
         flag-name: Unit Test
 
+  test_old:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: ['3.8']
+        django-version: ['3.2']
+    services:
+      mariadb:
+        image: mariadb:10.2
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: database
+        ports: ['3306:3306']
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: database
+        ports: ['6603:3306']
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Check for old SQLITE version
+      run: |
+        python -c 'import sqlite3,sys;print("SQLITE VERSION", sqlite3.sqlite_version_info);sys.exit(1 if sqlite3.sqlite_version_info >= (3, 33) else 0)'
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install "Django~=${{ matrix.django-version }}"
+        pip install -r example/requirements.txt
+    - name: Run Tests
+      run: |
+        echo -e "\nTEST: sqlite <3.33"
+        DBENGINE=sqlite coverage run --parallel-mode --source='fast_update' ./example/manage.py test exampleapp || exit 1
+        echo -e "\nTEST: mariadb 10.2"
+        DBENGINE=mysql coverage run --parallel-mode --source='fast_update' ./example/manage.py test exampleapp || exit 1
+        echo -e "\nTEST: mysql 5.7"
+        DBENGINE=mysql8 coverage run --parallel-mode --source='fast_update' ./example/manage.py test exampleapp || exit 1
+        coverage combine
+        coverage report
+        coverage html
+    - name: Coveralls
+      uses: AndreMiras/coveralls-python-action@develop
+      with:
+        parallel: true
+        flag-name: Unit Test
+
   coveralls_finish:
-    needs: [test]
+    needs: [test, test_old]
     runs-on: ubuntu-latest
     steps:
     - name: Coveralls Finished

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -113,6 +113,7 @@ elif DBENGINE == 'mysql':
     }
 elif DBENGINE == 'mysql8':
     # docker run --name some-mysql -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=database -p 6603:3306 -d mysql
+    # mysql:5.7.38 for mysql_old
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.mysql',

--- a/fast_update/fast.py
+++ b/fast_update/fast.py
@@ -106,7 +106,7 @@ def get_impl(conn: BaseDatabaseWrapper) -> str:
     if impl is not None:
         return impl
     check = CHECKER.get(conn.vendor)
-    if not check:
+    if not check:   # pragma: no cover
         SEEN_CONNECTIONS[conn] = tuple()
         return tuple()
     impl = check(conn)
@@ -316,7 +316,7 @@ def fast_update(
     model = qs.model
 
     ## fall back to bulk_update if we dont have a working fast_update impl
-    if not get_impl(conn):
+    if not get_impl(conn):  # pragma: no cover
         return qs.bulk_update(objs, fieldnames, batch_size)
 
     # filter all non model local fields --> still handled by bulk_update


### PR DESCRIPTION
TODO:
- [x] support for sqlite >=3.22 (still in Ubuntu 18.04 LTS)
- [x] support for mysql 5.7 (EOL in 1.5 years)
- [x] extend test matrix for sqlite <3.33 and mysql 5.7
- [x] revamp placeholder handling
- [x] revamp data patching (needed for mysql & old sqlite)
- [x] make implementations pluggable