### PR TITLE
update description_file to use `_` instead of `-`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [metadata]
-description-file = README.md
+description_file = README.md
 


### PR DESCRIPTION
The format of using `-` as a separator was deprecated by `setuptools` recently and is now breaking builds as this package is not installable with the newest versions.

Updating to use `_` as the separator should fix installations.

https://github.com/pypa/setuptools/issues/4910